### PR TITLE
"Import all" functionality, plus misc formatting amends

### DIFF
--- a/components/admin/settings.php
+++ b/components/admin/settings.php
@@ -122,6 +122,7 @@ class FacebookFanpageImportAdminSettings
 		/**
 		 * Import WP Cron settings
 		 */
+		$select_schedules = array( array( 'label' => __( 'Never', 'fbfpi' ), 'value' => 'never' ) );
 		$schedules = wp_get_schedules(); // Getting WordPress schedules
 		foreach( $schedules AS $key => $schedule )
 		{

--- a/components/admin/settings.php
+++ b/components/admin/settings.php
@@ -152,6 +152,25 @@ class FacebookFanpageImportAdminSettings
 		skip\select( 'insert_post_type', $args, __( 'Insert Messages as', 'fbfpi' ) );
 
 		/**
+		 * Select a category to apply to imported entries
+		 */
+		$args = array(
+			array(
+				'value' => 'none',
+				'label' => __( 'No category', 'fbfpi' ),
+			)
+		);
+		$terms = get_terms( 'category' );
+		foreach( $terms AS $term ) {
+			$args[] = array(
+				'value' => $term->term_id,
+				'label' => $term->name,
+			);
+		}
+
+		skip\select( 'insert_term_id', $args, __( 'Categorise Messages as', 'fbfpi' ) );
+
+		/**
 		 * Select importing User
 		 */
 		$users = get_users( array( 'fields' => array( 'ID', 'display_name' ) ) );

--- a/components/admin/settings.php
+++ b/components/admin/settings.php
@@ -240,7 +240,12 @@ class FacebookFanpageImportAdminSettings
 		 */
 		if( '' != skip\value( 'fbfpi_settings', 'page_id' ) )
 		{
-			echo ' <input type="submit" name="bfpi-now" value="' . __( 'Import Now', 'fbfpi' ) . '" class="button" style="margin-left:10px;" /> ';
+			if ( 'dddddddd' == get_option( '_facebook_fanpage_import_next', 'dddddddd' ) )
+			{
+				echo ' <input type="submit" name="bfpi-now" value="' . __( 'Import Now', 'fbfpi' ) . '" class="button" style="margin-left:10px;" /> ';
+			} else {
+				echo ' <input type="submit" name="bfpi-next" value="' . __( 'Import Next', 'fbfpi' ) . '" class="button" style="margin-left:10px;" /> <input type="submit" name="bfpi-stop" value="' . __( 'Stop', 'fbfpi' ) . '" class="button" style="margin-left:10px;" /> ';
+			}
 		}
 
 		skip\form_end();

--- a/components/admin/settings.php
+++ b/components/admin/settings.php
@@ -133,7 +133,7 @@ class FacebookFanpageImportAdminSettings
 		/**
 		 * Num of entries to import
 		 */
-		skip\select( 'update_num', '5,10,25,50,100,250,500,1000', __( 'Entries to import', 'fbfpi' ) );
+		skip\select( 'update_num', '5,10,25,50,100,250', __( 'Entries to import', 'fbfpi' ) );
 
 		/**
 		 * Select where to import, as posts or as own post type

--- a/components/import/facebook.php
+++ b/components/import/facebook.php
@@ -44,6 +44,11 @@ class FacebookFanpageConnect
 	var $page_id;
 
 	/**
+	 * @var Facebook Paging Object
+	 */
+	var $paging = null;
+
+	/**
 	 * @var string Locale settings
 	 */
 	var $locale;
@@ -163,7 +168,45 @@ class FacebookFanpageConnect
 
 		$data = json_decode( $data );
 
+		if ( property_exists( $data, 'paging' ) )
+		{
+			$this->paging = $data->paging;
+		}
+
 		return $data->data;
+	}
+
+	/**
+	 * Getting paged posts
+	 *
+	 * @param string $url The "next page" URL returned by Graph API
+	 *
+	 * @return mixed
+	 */
+	function get_posts_paged( $url )
+	{
+
+		$data = $this->fetch_data( $url );
+		$data = json_decode( $data );
+
+		if ( property_exists( $data, 'paging' ) )
+		{
+			$this->paging = $data->paging;
+		}
+
+		return $data->data;
+	}
+
+	/**
+	 * Gets the paging object
+	 *
+	 * @param string $url The "next page" URL returned by Graph API
+	 *
+	 * @return mixed
+	 */
+	function get_paging()
+	{
+		return $this->paging;
 	}
 
 	/**

--- a/components/import/facebook.php
+++ b/components/import/facebook.php
@@ -56,7 +56,7 @@ class FacebookFanpageConnect
 	function __construct( $page_id, $access_token = '', $locale = 'en_EN' )
 	{
 		$this->access_token = '1412978082344911|a7f5722a2b02f24aad0cda61ae5c4fe9';
-		$this->graph_url = 'https://graph.facebook.com/v2.1/';
+		$this->graph_url = 'https://graph.facebook.com/v2.3/';
 		$this->locale = $locale;
 
 		if( '' != $access_token )

--- a/components/import/import-stream.php
+++ b/components/import/import-stream.php
@@ -183,7 +183,7 @@ class FacebookFanpageImportFacebookStream
 			foreach( $entries AS $entry )
 			{
 
-				$sql = $wpdb->prepare( "SELECT COUNT(*) FROM $wpdb->posts AS p, $wpdb->postmeta AS m WHERE p.ID = m.post_id  AND p.post_type='%s' AND p.post_status <> 'trash' AND m.meta_key = 'entry_id'  AND m.meta_value = '%s'", $post_type, $entry->id );
+				$sql = $wpdb->prepare( "SELECT COUNT(*) FROM $wpdb->posts AS p, $wpdb->postmeta AS m WHERE p.ID = m.post_id  AND p.post_type='%s' AND p.post_status <> 'trash' AND m.meta_key = '_fbfpi_entry_id'  AND m.meta_value = '%s'", $post_type, $entry->id );
 				$post_count = $wpdb->get_var( $sql );
 
 				if( $post_count > 0 ) // If entry already exists

--- a/components/import/import-stream.php
+++ b/components/import/import-stream.php
@@ -571,7 +571,15 @@ class FacebookFanpageImportFacebookStream
 		$content .= '<div class="fbfpi_video">';
 		$content .= '[embed]' . $entry->link . '[/embed]';
 		$content .= '<div class="fbfpi_text">';
-		$content .= '<h4><a href="' . $entry->link . '" target="' . $this->link_target . '">' . $entry->name . '</a></h4>';
+
+		// set a default title if none exists
+		if( property_exists( $entry, 'name' ) ) {
+			$name = $entry->name;
+		} else {
+			$name = __( 'Untitled video', 'fbfpi' );
+		}
+
+		$content .= '<h4><a href="' . $entry->link . '" target="' . $this->link_target . '">' . $name . '</a></h4>';
 
 		if( property_exists( $entry, 'description' ) )
 		{

--- a/components/import/import-stream.php
+++ b/components/import/import-stream.php
@@ -167,9 +167,15 @@ class FacebookFanpageImportFacebookStream
 
 				if( !property_exists( $entry, 'message' ) )
 				{
-					$post_title = $entry->story;
-					$skip_without_message++;
-					continue;
+
+					if( property_exists( $entry, 'story' ) && '' != $entry->story ) {
+						$post_title = $entry->story;
+						$entry->message = '';
+					} else {
+						$post_title = __( 'Untitled post', 'fbfpi' );
+						$entry->message = '';
+					}
+
 				}
 				elseif( property_exists( $entry, 'message' ) && '' != $entry->message )
 				{

--- a/components/import/import-stream.php
+++ b/components/import/import-stream.php
@@ -92,6 +92,16 @@ class FacebookFanpageImportFacebookStream
 			add_action( 'init', array( $this, 'import' ), 12 );
 		}
 
+		if( array_key_exists( 'bfpi-next', $_POST ) && '' != $_POST[ 'bfpi-next' ] )
+		{
+			add_action( 'init', array( $this, 'import' ), 12 );
+		}
+
+		if( array_key_exists( 'bfpi-stop', $_POST ) && '' != $_POST[ 'bfpi-stop' ] )
+		{
+			delete_option( '_facebook_fanpage_import_next' );
+		}
+
 		add_action( 'admin_notices', array( $this, 'admin_notices' ) );
 	}
 

--- a/components/import/import-stream.php
+++ b/components/import/import-stream.php
@@ -366,8 +366,8 @@ class FacebookFanpageImportFacebookStream
 		$title = explode( '!', $title );
 		$title = $title[ 0 ];
 
-		$title = explode( '.', $title );
-		$title = $title[ 0 ];
+		//$title = explode( '.', $title );
+		//$title = $title[ 0 ];
 
 		$title = str_replace( '+', '', $title );
 

--- a/components/import/import-stream.php
+++ b/components/import/import-stream.php
@@ -348,6 +348,21 @@ class FacebookFanpageImportFacebookStream
 				}
 				wp_update_post( $post );
 
+				// assign term if one is set
+				$term_id = skip\value( 'fbfpi_settings', 'insert_term_id' );
+				if ( $term_id != 'none' ) {
+					$cat_ids = array( intval( $term_id ) );
+					$term_taxonomy_ids = wp_set_object_terms( $post->ID, $cat_ids, 'category' );
+					if ( is_wp_error( $term_taxonomy_ids ) ) {
+						// term could not be set
+						error_log( print_r( array(
+							'method' => __METHOD__,
+							'term could not be set' => $term_id,
+							'entry' => $entry,
+						), true ) );
+					}
+				}
+
 				// skip\p($entry);
 
 				// Updating post meta

--- a/components/import/import-stream.php
+++ b/components/import/import-stream.php
@@ -82,7 +82,7 @@ class FacebookFanpageImportFacebookStream
 		// Scheduling import
 		if( !wp_next_scheduled( 'fanpage_import' ) )
 		{
-			//wp_schedule_event( time(), $this->update_interval, 'fanpage_import' );
+			wp_schedule_event( time(), $this->update_interval, 'fanpage_import' );
 		}
 
 		add_action( 'fanpage_import', array( $this, 'import' ) );

--- a/components/import/import-stream.php
+++ b/components/import/import-stream.php
@@ -578,6 +578,43 @@ class FacebookFanpageImportFacebookStream
 		$content = $entry->message;
 		$content .= '<div class="fbfpi_photo">';
 		$content .= '<img src="' . $attach_url . '">';
+
+		// conditionally add descriptive content
+		if (
+			property_exists( $entry, 'name' ) OR
+			property_exists( $entry, 'link' ) OR
+			property_exists( $entry, 'description' )
+		) {
+
+			// wrapper
+			$content .= '<div class="fbfpi_text">';
+
+			// add name if present
+			$title = '';
+			if ( property_exists( $entry, 'name' ) ) {
+				$title = $entry->name;
+			} else {
+				$title = __( 'Untitled photo', 'fbfpi' );
+			}
+
+			// wrap in link if present
+			if ( property_exists( $entry, 'link' ) ) {
+				$title = '<a href="' . $entry->link . '" target="' . $this->link_target . '">' . $title. '</a>';
+			}
+
+			// make heading and add
+			$title = '<h4>' . $title . '</h4>';
+			$content .= $title;
+
+			// add description if present
+			if ( property_exists( $entry, 'description' ) ) {
+				$content .= '<p>' . $entry->description . '</p>';
+			}
+
+			$content .= '</div>';
+
+		}
+
 		$content .= '</div>';
 
 		return $content;

--- a/components/import/import-stream.php
+++ b/components/import/import-stream.php
@@ -79,10 +79,27 @@ class FacebookFanpageImportFacebookStream
 			$this->update_num = FALSE;
 		}
 
-		// Scheduling import
-		if( !wp_next_scheduled( 'fanpage_import' ) )
+		// Schedule import if interval set
+		if ( $this->update_interval != 'never' )
 		{
-			wp_schedule_event( time(), $this->update_interval, 'fanpage_import' );
+			if( !wp_next_scheduled( 'fanpage_import' ) )
+			{
+				wp_schedule_event( time(), $this->update_interval, 'fanpage_import' );
+			}
+		}
+		else
+		{
+			// get next scheduled event
+			$timestamp = wp_next_scheduled( 'fanpage_import' );
+
+			// unschedule it if there is one
+			if ( $timestamp !== false ) {
+				wp_unschedule_event( $timestamp, 'fanpage_import' );
+			}
+
+			// it's not clear whether wp_unschedule_event() clears everything,
+			// so remove existing scheduled hook as well
+			wp_clear_scheduled_hook( 'fanpage_import' );
 		}
 
 		add_action( 'fanpage_import', array( $this, 'import' ) );

--- a/components/import/import-stream.php
+++ b/components/import/import-stream.php
@@ -565,7 +565,8 @@ class FacebookFanpageImportFacebookStream
 	 */
 	private function get_video_content( $entry )
 	{
-		$content = $entry->message;
+
+		$content = $entry->message . "\n\n";
 
 		$content .= '<div class="fbfpi_video">';
 		$content .= '[embed]' . $entry->link . '[/embed]';

--- a/components/import/import-stream.php
+++ b/components/import/import-stream.php
@@ -380,6 +380,14 @@ class FacebookFanpageImportFacebookStream
 					set_post_format( $post_id, $post_format );
 				}
 
+				/**
+				 * Allow plugins to do additional processing.
+				 *
+				 * @param WP_Post $post The post object
+				 * @param object $entry The Facebook entry object
+				 */
+				do_action( 'fbfpi_entry_created', $post, $entry );
+
 				$i++;
 			}
 
@@ -440,7 +448,14 @@ class FacebookFanpageImportFacebookStream
 			$title = $title . ' ...';
 		}
 
-		return $title;
+		/**
+		 * Allow overrides.
+		 *
+		 * @param string $title The filtered title
+		 * @param string $string The unfiltered title
+		 * @return string $title The filtered title
+		 */
+		return apply_filters( 'fbfpi_entry_title', $title, $string );
 	}
 
 	/**
@@ -587,7 +602,15 @@ class FacebookFanpageImportFacebookStream
 		$content .= '</div>';
 		$content .= '</div>';
 
-		return $content;
+		/**
+		 * Allow overrides.
+		 *
+		 * @param string $content The constructed content
+		 * @param object $entry The entry object
+		 * @param integer $attach_id The numeric ID of the attachment
+		 * @return string $content The constructed content
+		 */
+		return apply_filters( 'fbfpi_entry_link', $content, $entry, $attach_id );
 	}
 
 	/**
@@ -644,7 +667,15 @@ class FacebookFanpageImportFacebookStream
 
 		$content .= '</div>';
 
-		return $content;
+		/**
+		 * Allow overrides.
+		 *
+		 * @param string $content The constructed content
+		 * @param object $entry The entry object
+		 * @param integer $attach_id The numeric ID of the attachment
+		 * @return string $content The constructed content
+		 */
+		return apply_filters( 'fbfpi_entry_photo', $content, $entry, $attach_id );
 	}
 
 	/**
@@ -685,7 +716,14 @@ class FacebookFanpageImportFacebookStream
 		$content .= '</div>';
 		$content .= '</div>';
 
-		return $content;
+		/**
+		 * Allow overrides.
+		 *
+		 * @param string $content The constructed content
+		 * @param object $entry The entry object
+		 * @return string $content The constructed content
+		 */
+		return apply_filters( 'fbfpi_entry_video', $content, $entry );
 	}
 
 	/**

--- a/components/import/import-stream.php
+++ b/components/import/import-stream.php
@@ -569,7 +569,13 @@ class FacebookFanpageImportFacebookStream
 		$content = $entry->message . "\n\n";
 
 		$content .= '<div class="fbfpi_video">';
-		$content .= '[embed]' . $entry->link . '[/embed]';
+
+		// support JetPack's "facebook" shortcode for Facebook videos
+		if ( shortcode_exists( 'facebook' ) && false !== strpos( $entry->link, 'www.facebook.com' ) ) {
+			$content .= '[facebook url="' . $entry->link . '"]';
+		} else {
+			$content .= '[embed]' . $entry->link . '[/embed]';
+		}
 		$content .= '<div class="fbfpi_text">';
 
 		// set a default title if none exists

--- a/components/import/import-stream.php
+++ b/components/import/import-stream.php
@@ -330,23 +330,23 @@ class FacebookFanpageImportFacebookStream
 
 				if( property_exists( $entry, 'id' ) )
 				{
-					update_post_meta( $post_id, 'entry_id', $entry->id );
+					update_post_meta( $post_id, '_fbfpi_entry_id', $entry->id );
 				}
 				if( property_exists( $entry, 'message' ) )
 				{
-					update_post_meta( $post_id, 'message', $entry->message );
+					update_post_meta( $post_id, '_fbfpi_message', $entry->message );
 				}
 				if( property_exists( $entry, 'description' ) )
 				{
-					update_post_meta( $post_id, 'description', $entry->description );
+					update_post_meta( $post_id, '_fbfpi_description', $entry->description );
 				}
 
-				update_post_meta( $post_id, 'image_url', $post_picture );
-				update_post_meta( $post_id, 'fanpage_id', $this->page_id );
-				update_post_meta( $post_id, 'fanpage_name', $page_details->name );
-				update_post_meta( $post_id, 'fanpage_link', $page_details->link );
-				update_post_meta( $post_id, 'entry_url', $entry_url );
-				update_post_meta( $post_id, 'type', $entry->type );
+				update_post_meta( $post_id, '_fbfpi_image_url', $post_picture );
+				update_post_meta( $post_id, '_fbfpi_fanpage_id', $this->page_id );
+				update_post_meta( $post_id, '_fbfpi_fanpage_name', $page_details->name );
+				update_post_meta( $post_id, '_fbfpi_fanpage_link', $page_details->link );
+				update_post_meta( $post_id, '_fbfpi_entry_url', $entry_url );
+				update_post_meta( $post_id, '_fbfpi_type', $entry->type );
 
 				if( 'none' != $post_format )
 				{

--- a/components/showdata/shortcodes.php
+++ b/components/showdata/shortcodes.php
@@ -84,16 +84,16 @@ class FacebookFanpageImportShowdataShortcodes
 				// setup_postdata( $post );
 				$post_id = $wp_query->post->ID;
 
-				$fanpage_id = get_post_meta( $post_id, 'fanpage_id', TRUE );
-				$fanpage_name = get_post_meta( $post_id, 'fanpage_name', TRUE );
-				$fanpage_link = get_post_meta( $post_id, 'fanpage_link', TRUE );
+				$fanpage_id = get_post_meta( $post_id, '_fbfpi_fanpage_id', TRUE );
+				$fanpage_name = get_post_meta( $post_id, '_fbfpi_fanpage_name', TRUE );
+				$fanpage_link = get_post_meta( $post_id, '_fbfpi_fanpage_link', TRUE );
 
-				$id = get_post_meta( $post_id, 'post_id', TRUE );
-				$entry_id = get_post_meta( $post_id, 'entry_id', TRUE );
-				$message = nl2br( get_post_meta( $post_id, 'message', TRUE ) );
-				$description = get_post_meta( $post_id, 'description', TRUE );
-				$permalink = get_post_meta( $post_id, 'permalink', TRUE );
-				$type = get_post_meta( $post_id, 'type', TRUE );
+				$id = get_post_meta( $post_id, '_fbfpi_post_id', TRUE );
+				$entry_id = get_post_meta( $post_id, '_fbfpi_entry_id', TRUE );
+				$message = nl2br( get_post_meta( $post_id, '_fbfpi_message', TRUE ) );
+				$description = get_post_meta( $post_id, '_fbfpi_description', TRUE );
+				$permalink = get_post_meta( $post_id, '_fbfpi_permalink', TRUE );
+				$type = get_post_meta( $post_id, '_fbfpi_type', TRUE );
 
 				$link_target = skip\value( 'fbfpi_settings', 'link_target' );
 

--- a/includes/css/display.css
+++ b/includes/css/display.css
@@ -22,3 +22,6 @@
 	display:block;
 	line-height: 0;
 }
+.fbfpi_video{
+	border:1px solid #ccc;
+}

--- a/includes/css/display.css
+++ b/includes/css/display.css
@@ -1,27 +1,47 @@
-/* This stylesheet is used to style the public view of the plugin. */
-.fbfpi_link{
-	border:1px solid #ccc;
+/**
+ * This stylesheet is used to style the public view of the plugin.
+ *
+ * @since 1.0.0
+ */
+
+/* link wrapper */
+.fbfpi_link {
+	border: 1px solid #ccc;
 }
-.fbfpi_link a{
-	text-decoration:none;
+.fbfpi_link a {
+	text-decoration: none;
 }
-.fbfpi_text{
-	padding:10px;
+
+/* text wrapper */
+.fbfpi_text {
+	padding: 10px;
 }
-.fbfpi_text h4{
+.fbfpi_text h4 {
 	margin: 0;
 }
-.fbfpi_text p{
+.fbfpi_text h4 a {
+	text-decoration: none;
+}
+.fbfpi_text p {
 	margin: 5px 0 0 0;
 }
-.fbfpi_image{
+
+/* image wrapper */
+.fbfpi_image {
 	background-color: #EFEFEF;
-	text-align:center;
+	text-align: center;
 }
-.fbfpi_image a{
-	display:block;
+.fbfpi_image a {
+	display: block;
 	line-height: 0;
 }
-.fbfpi_video{
-	border:1px solid #ccc;
+
+/* photo wrapper */
+.fbfpi_photo {
+	border: 1px solid #ccc;
+}
+
+/* video wrapper */
+.fbfpi_video {
+	border: 1px solid #ccc;
 }


### PR DESCRIPTION
Thank you for this plugin - it's done almost everything that I needed.

This PR isn't really meant to be merged, more a way of letting you know of my updates to your plugin which filled in the gaps. You can cherry-pick any commits that you think might be useful, of course.

So then, I needed to export the entire history of a Facebook Page, but because there are limits to the number of fetched items, your plugin would only fetch the first 250. I have added code to provide a rudimentary UI for stepping through "pages" of fetched data until there are no more left. Existing `wp_schedule_event` imports should be unaffected.

There are also a number of commits dealing with formatting which can be ignored unless you find them helpful. The most important one in my opinion is 815e9e4, because I found the `[embed]` shortcode failed to handle native Facebook videos. JetPack's `[facebook]` shortcode works as expected, hence the support for it.