### PR TITLE
Ensure var is empty on each iteration

### DIFF
--- a/components/import/import-stream.php
+++ b/components/import/import-stream.php
@@ -155,6 +155,9 @@ class FacebookFanpageImportFacebookStream
 					continue;
 				}
 
+				// init picture URL
+				$picture_url = '';
+
 				// Get post picture URL (Made here, because needed twice)
 				$post_picture = $ffbc->get_post_picture( $entry->id );
 				if( property_exists( $post_picture, 'full_picture' ) )

--- a/components/import/import-stream.php
+++ b/components/import/import-stream.php
@@ -155,8 +155,9 @@ class FacebookFanpageImportFacebookStream
 					continue;
 				}
 
-				// init picture URL
+				// init picture URL and attach ID
 				$picture_url = '';
+				$attach_id = '';
 
 				// Get post picture URL (Made here, because needed twice)
 				$post_picture = $ffbc->get_post_picture( $entry->id );


### PR DESCRIPTION
When `$picture_url` is not populated on an iteration, the previous value is retained. This leads to incorrect images being assigned to posts.