### PR TITLE
Add meta box Facebook Post Infos

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -40,6 +40,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= 1.0.0-beta.8 =
+* Added a new meta box dedicated to Facebook Post Infos (now only URL)
+
 = 1.0.0-beta.7 =
 * Fixed: Added Text Domain to plugin header
 

--- a/README.txt
+++ b/README.txt
@@ -8,7 +8,7 @@ Contributors:      mahype, awesome-ug
 Requires at least: 4.1.1
 Tested up to:      4.6.0
 Stable tag:        1.0.0-beta.7
-Version:           1.0.0-beta.7
+Version:           1.0.0-beta.8
 License:           GNU General Public License v3
 License URI:       http://www.gnu.org/licenses/gpl-3.0.html
 Tags:              facebook, fanpage, import

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-fanpage-import",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "description": "Easy import Facebook Fanpage messages to your WordPress.",
   "keywords": [
     "facebook",

--- a/components/admin/component.php
+++ b/components/admin/component.php
@@ -79,7 +79,7 @@ class FacebookFanpageImportAdmin {
 	/**
 	 * Add Meta Box for Facebook Post infos
 	 *
-	 * @since 1.0.1
+	 * @since 1.0.0
 	 */
 	public function custom_meta_box() {
 		add_meta_box( 'facebook-post-info-meta-box', __( 'Facebook Post Infos', 'fbfpi-locale' ), array( $this, 'meta_box_output'), 'status-message', 'side', 'high' );
@@ -88,7 +88,7 @@ class FacebookFanpageImportAdmin {
 	/**
 	 * Output the Meta box on backoffice
 	 *
-	 * @since 1.0.1
+	 * @since 1.0.0
 	 */
 	public function meta_box_output( $post ) {
 		// create a nonce field
@@ -105,7 +105,7 @@ class FacebookFanpageImportAdmin {
 	/**
 	 * Save the Meta box value
 	 *
-	 * @since 1.0.1
+	 * @since 1.0.0
 	 */
 	public function custom_meta_box_save( $post_id ) {
 		// Stop the script when doing autosave
@@ -125,7 +125,7 @@ class FacebookFanpageImportAdmin {
 	/**
 	 * Return the custom field selected
 	 *
-	 * @since 1.0.1
+	 * @since 1.0.0
 	 */
 	private function get_custom_field( $value ) {
 		global $post;

--- a/components/import/import-stream.php
+++ b/components/import/import-stream.php
@@ -324,6 +324,7 @@ class FacebookFanpageImportFacebookStream {
 
 				if ( property_exists( $entry, 'id' ) ) {
 					update_post_meta( $post_id, '_fbfpi_entry_id', $entry->id );
+					update_post_meta( $post_id, 'fbfpi_facebook_post_url', 'https://www.facebook.com/' . $entry->id );
 				}
 				if ( property_exists( $entry, 'message' ) ) {
 					update_post_meta( $post_id, '_fbfpi_message', $entry->message );

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "awsmug/fanpage-import",
   "description": "Easy import Facebook Fanpage messages to your WordPress.",
-  "version": "1.0.0-beta.7,
+  "version": "1.0.0-beta.8",
   "license": "GPL-3.0",
   "type": "wordpress-plugin",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-fanpage-import",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "description": "Easy import Facebook Fanpage messages to your WordPress.",
   "keywords": [
     "facebook",


### PR DESCRIPTION
With this new meta box the content user can see (and edit) all Facebook Post infos (now only the URL by ID).