### PR TITLE
Edited get_post_excerpt function to avoid very long excerpt

### DIFF
--- a/components/import/import-stream.php
+++ b/components/import/import-stream.php
@@ -535,9 +535,11 @@ class FacebookFanpageImportFacebookStream {
 	 */
 	private function get_post_excerpt( $entry ) {
 		$post_excerpt = '';
-		if ( property_exists( $entry, 'message' ) ) {
+		if ( property_exists( $entry, 'description' ) ) {
+			$post_excerpt = $entry->description;
+		}else if ( property_exists( $entry, 'message' ) ) {
 			$post_excerpt = $entry->message;
-		}
+ 		}
 
 		/**
 		 * Allow overrides.


### PR DESCRIPTION
Reading the excerpt only by `message` param could generate very long excerpt and this will not be nice.

With the param `description` we read a short description of the message .